### PR TITLE
 	Fixed numbers for series.bars.align.center and series.bars.align.right, added a font object with size, style, weight, family, color settings, optimized some code.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,15 +14,7 @@ simple flot plugin to draw bar numbers in bars, simply add
         }
     }
 
-The below will continue to work for now to prevent breaking of existing code
-
-    series: {
-        bars: {
-            showNumbers: boolean
-        }
-    }
-
-There are 2 other additional options
+There are other additional options
 
     series: {
         bars: {

--- a/README.md
+++ b/README.md
@@ -27,8 +27,10 @@ There are 2 other additional options
     series: {
         bars: {
             numbers: {
+                show : boolean,
                 xAlign : function or number,
                 yAlign : function or number,
+                font : {size : number, style : string, weight : string, family : string, color : string}
             }
         }
     }
@@ -37,8 +39,3 @@ By default numbers will be positioned in the center of the bars, you can
 specify a function or a number to override this behaviour. If you have a
 horizontal bar chart, these 2 functions will switch round the axes they
 are working on.
-
-
-Todo
-====
-* currently breaks at series.bars.align : "center"

--- a/README.md
+++ b/README.md
@@ -18,16 +18,16 @@ There are other additional options
 
     series: {
         bars: {
-            numbers: {
+            numbers : {
                 show : boolean,
-                xAlign : function or number,
-                yAlign : function or number,
+                xAlign : null or function like function (x) {return x + 0.5;}, (if null, the text is in the middle)
+                yAlign : null or function like function (y) {return y + 0.5;}, (if null, the text is in the middle)
                 font : {size : number, style : string, weight : string, family : string, color : string}
             }
         }
     }
 
-By default numbers will be positioned in the center of the bars, you can
-specify a function or a number to override this behaviour. If you have a
-horizontal bar chart, these 2 functions will switch round the axes they
-are working on.
+By default numbers will be positioned in the center of the bars, but you can specify a function to override this behaviour.
+If you have a horizontal bar chart, these 2 functions will switch round the axes they are working on.
+
+This plugin is working well with zooming and panning (navigation plugin) too.

--- a/jquery.flot.barnumbers.js
+++ b/jquery.flot.barnumbers.js
@@ -36,8 +36,7 @@
         }
         
         var numbers = options.series.bars.numbers;
-        var horizontal = options.series.bars.horizontal;
-        
+        var horizontal = options.series.bars.horizontal;        
         if (horizontal) {
             numbers.xAlign = numbers.xAlign || function (x) {return x / 2;};
             numbers.yAlign = numbers.yAlign || function (y) {return y + alignOffset;};
@@ -47,11 +46,6 @@
             numbers.yAlign = numbers.yAlign || function (y) {return y / 2;};
             numbers.horizontalShift = 1;
         }
-        
-        numbers.xaxismin = options.xaxis.min;
-        numbers.xaxismax = options.xaxis.max;
-        numbers.yaxismin = options.yaxis.min;
-        numbers.yaxismax = options.yaxis.max;
     }
 
     function draw(plot, ctx) {
@@ -59,9 +53,10 @@
             if (series.bars.numbers.show) {
                 var ps = series.datapoints.pointsize;
                 var points = series.datapoints.points;
-                var ctx = plot.getCanvas().getContext('2d');
+                //var ctx = plot.getCanvas().getContext('2d');
                 var offset = plot.getPlotOffset();
                 
+                ctx.save();
                 ctx.textBaseline = "middle";
                 ctx.textAlign = "center";
                 
@@ -107,11 +102,11 @@
                         text = points[barNumber];
                     }
                     
-                    // check against axis min. / max.
-                    if ((series.bars.numbers.xaxismin && point.x < series.bars.numbers.xaxismin) ||
-                        (series.bars.numbers.xaxismax && point.x > series.bars.numbers.xaxismax) ||
-                        (series.bars.numbers.yaxismin && point.y < series.bars.numbers.yaxismin) ||
-                        (series.bars.numbers.yaxismax && point.y > series.bars.numbers.yaxismax)) {
+                    // check against axis min. / max.                  
+                    if ((series.xaxis.min && point.x < series.xaxis.min) ||
+                        (series.xaxis.max && point.x > series.xaxis.max) ||
+                        (series.yaxis.min && point.y < series.yaxis.min) ||
+                        (series.yaxis.max && point.y > series.yaxis.max)) {
                         // don't render this number because it is out of range
                         continue; 
                     }
@@ -125,6 +120,8 @@
                     
                     ctx.fillText(txt, c.left + offset.left, c.top + offset.top + 1);
                 }
+                
+                ctx.restore();
             }
         });
     }

--- a/jquery.flot.barnumbers.js
+++ b/jquery.flot.barnumbers.js
@@ -37,6 +37,7 @@
         
         var numbers = options.series.bars.numbers;
         var horizontal = options.series.bars.horizontal;
+        
         if (horizontal) {
             numbers.xAlign = numbers.xAlign || function (x) {return x / 2;};
             numbers.yAlign = numbers.yAlign || function (y) {return y + alignOffset;};
@@ -46,6 +47,11 @@
             numbers.yAlign = numbers.yAlign || function (y) {return y / 2;};
             numbers.horizontalShift = 1;
         }
+        
+        numbers.xaxismin = options.xaxis.min;
+        numbers.xaxismax = options.xaxis.max;
+        numbers.yaxismin = options.yaxis.min;
+        numbers.yaxismax = options.yaxis.max;
     }
 
     function draw(plot, ctx) {
@@ -101,6 +107,15 @@
                         text = points[barNumber];
                     }
                     
+                    // check against axis min. / max.
+                    if ((series.bars.numbers.xaxismin && point.x < series.bars.numbers.xaxismin) ||
+                        (series.bars.numbers.xaxismax && point.x > series.bars.numbers.xaxismax) ||
+                        (series.bars.numbers.yaxismin && point.y < series.bars.numbers.yaxismin) ||
+                        (series.bars.numbers.yaxismax && point.y > series.bars.numbers.yaxismax)) {
+                        // don't render this number because it is out of range
+                        continue; 
+                    }
+                    
                     var c = plot.p2c(point);
                     var txt = text.toString(10);
                     
@@ -123,6 +138,6 @@
         init: init,
         options: options,
         name: 'barnumbers',
-        version: '0.5'
+        version: '0.6'
     });
 })(jQuery);

--- a/jquery.flot.barnumbers.js
+++ b/jquery.flot.barnumbers.js
@@ -6,8 +6,8 @@
  *     bars: {
  *         numbers : {
  *             show : boolean,
- *             alignX : number or function,
- *             alignY : number or function,
+ *             xAlign : null or function like function (x) {return x + 0.5;}, (if null, the text is in the middle)
+ *             yAlign : null or function like function (y) {return y + 0.5;}, (if null, the text is in the middle)
  *             font : {size : number, style : string, weight : string, family : string, color : string}
  *         }
  *     }
@@ -63,6 +63,7 @@
                 if (font) {
                     if (font.color) {
                         ctx.fillStyle = font.color;
+                        ctx.strokeStyle = font.color;  // for better look
                     }
                     
                     var fontStr = font.weight ? font.weight : "";
@@ -76,9 +77,6 @@
                 
                 var xAlign = series.bars.numbers.xAlign;
                 var yAlign = series.bars.numbers.yAlign;
-                
-                var shiftX = typeof xAlign == "number" ? function (x) {return x;} : xAlign;                
-                var shiftY = typeof yAlign == "number" ? function (y) {return y;} : yAlign;
 
                 var axes = {
                     0: 'x',
@@ -90,20 +88,27 @@
                     var barNumber = i + hs;
                     
                     var point = {
-                        'x': shiftX(points[i]),
-                        'y': shiftY(points[i + 1])
+                        'x': xAlign(points[i]),
+                        'y': yAlign(points[i + 1])
                     };
                     
                     var text;
                     if (series.stack != null) {
-                        point[axes[hs]] = (points[barNumber] - series.data[i / 3][hs] / 2);
-                        text = series.data[i / 3][hs];
+                        var value = series.data[i / 3][hs];
+                        point[axes[hs]] = (points[barNumber] - value + (hs == 0 ? xAlign(value) : yAlign(value)));
+                        text = value;
                     } else {
                         text = points[barNumber];
                     }
                     
                     var c = plot.p2c(point);
-                    ctx.fillText(text.toString(10), c.left + offset.left, c.top + offset.top + 1);
+                    var txt = text.toString(10);
+                    
+                    // stroke for better look
+                    ctx.lineWidth = 0.2;
+                    ctx.strokeText(txt, c.left + offset.left, c.top + offset.top + 1);
+                    
+                    ctx.fillText(txt, c.left + offset.left, c.top + offset.top + 1);
                 }
             }
         });


### PR DESCRIPTION
Please review and accept my changes. I've fixed vertical alignment of numbers in stacked bars. As you can see here http://joetsoi.github.io/flot-barnumbers/, numbers in the last two examples are not well vertical aligned. Furthermore, I added support for center and right oriented bars and added a "font" object to be able to set font specific settings. Example:

```
numbers: {
    show: true,
    font: {size: 12, style: "italic", weight: "bold", family: "Arial", color: "blue"}
}
```

I also done some optimizations like removing of duplicate code snippets.

Thanks in advance.