### PR TITLE
Added support for font color

### DIFF
--- a/jquery.flot.barnumbers.js
+++ b/jquery.flot.barnumbers.js
@@ -43,6 +43,13 @@
                 var points = series.datapoints.points;
                 var ctx = plot.getCanvas().getContext('2d');
                 var offset = plot.getPlotOffset();
+                
+                var fontcolor = series.bars.numbers.color;
+
+                if(typeof(fontcolor) != 'undefined'){
+                    ctx.fillStyle = fontcolor;
+                }
+                
                 ctx.textBaseline = "top";
                 ctx.textAlign = "center";
                 alignOffset = series.bars.align === "left" ? series.bars.barWidth / 2 : 0;


### PR DESCRIPTION
color may now be set as series.bars.numbers.color parameter. black by default.

e.g.:
series: { bars: { show: true, numbers: { show: true, color: "#ffffff" } } }