### PR TITLE
series.bars.align : "center" fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,4 +41,4 @@ are working on.
 
 Todo
 ====
-* currently breaks at series.bars.align : "center"
+None

--- a/jquery.flot.barnumbers.js
+++ b/jquery.flot.barnumbers.js
@@ -30,7 +30,11 @@
             numbers.yAlign = numbers.yAlign || function(y){ return y + (bw / 2); };
             numbers.horizontalShift = 0;
         } else {
-            numbers.xAlign = numbers.xAlign || function(x){ return x + (bw / 2); };
+			if(options.series.bars.align === "center") {
+	            numbers.xAlign = numbers.xAlign || function(x){ return x; };
+			} else {
+	            numbers.xAlign = numbers.xAlign || function(x){ return x + (bw / 2); };
+			}
             numbers.yAlign = numbers.yAlign || function(y){ return y / 2; };
             numbers.horizontalShift = 1;
         }
@@ -44,11 +48,11 @@
                 var ctx = plot.getCanvas().getContext('2d');
                 var offset = plot.getPlotOffset();
                 ctx.textBaseline = "top";
-                ctx.textAlign = "center";
+				ctx.textAlign = "center";
                 alignOffset = series.bars.align === "left" ? series.bars.barWidth / 2 : 0;
-                xAlign = series.bars.numbers.xAlign;
+				xAlign = series.bars.numbers.xAlign;
                 yAlign = series.bars.numbers.yAlign;
-                var shiftX = typeof xAlign == "number" ? function(x){ return x; } : xAlign;
+				var shiftX = typeof xAlign == "number" ? function(x){ return x; } : xAlign;
                 var shiftY = typeof yAlign == "number" ? function(y){ return y; } : yAlign;
     
                 axes = {
@@ -57,7 +61,7 @@
                 } 
                 hs = series.bars.numbers.horizontalShift;
                 for(var i = 0; i < points.length; i += ps){
-                    barNumber = i + series.bars.numbers.horizontalShift
+					barNumber = i + series.bars.numbers.horizontalShift
                     var point = {
                         'x': shiftX(points[i]),
                         'y': shiftY(points[i+1])

--- a/jquery.flot.barnumbers.js
+++ b/jquery.flot.barnumbers.js
@@ -50,8 +50,8 @@
                 ctx.textBaseline = "top";
                 ctx.textAlign = "center";
                 alignOffset = series.bars.align === "left" ? series.bars.barWidth / 2 : 0;
-				xAlign = series.bars.numbers.xAlign;
-				yAlign = series.bars.numbers.yAlign;
+                xAlign = series.bars.numbers.xAlign;
+                yAlign = series.bars.numbers.yAlign;
 				var shiftX = typeof xAlign == "number" ? function(x){ return x; } : xAlign;
                 var shiftY = typeof yAlign == "number" ? function(y){ return y; } : yAlign;
     

--- a/jquery.flot.barnumbers.js
+++ b/jquery.flot.barnumbers.js
@@ -30,11 +30,11 @@
             numbers.yAlign = numbers.yAlign || function(y){ return y + (bw / 2); };
             numbers.horizontalShift = 0;
         } else {
-			if(options.series.bars.align === "center") {
-	            numbers.xAlign = numbers.xAlign || function(x){ return x; };
-			} else {
-	            numbers.xAlign = numbers.xAlign || function(x){ return x + (bw / 2); };
-			}
+            if(options.series.bars.align === "center") {
+                numbers.xAlign = numbers.xAlign || function(x){ return x; };
+            } else {
+                numbers.xAlign = numbers.xAlign || function(x){ return x + (bw / 2); };
+            }
             numbers.yAlign = numbers.yAlign || function(y){ return y / 2; };
             numbers.horizontalShift = 1;
         }
@@ -51,7 +51,7 @@
                 ctx.textAlign = "center";
                 alignOffset = series.bars.align === "left" ? series.bars.barWidth / 2 : 0;
 				xAlign = series.bars.numbers.xAlign;
-                yAlign = series.bars.numbers.yAlign;
+				yAlign = series.bars.numbers.yAlign;
 				var shiftX = typeof xAlign == "number" ? function(x){ return x; } : xAlign;
                 var shiftY = typeof yAlign == "number" ? function(y){ return y; } : yAlign;
     
@@ -61,7 +61,7 @@
                 } 
                 hs = series.bars.numbers.horizontalShift;
                 for(var i = 0; i < points.length; i += ps){
-                	barNumber = i + series.bars.numbers.horizontalShift
+                    barNumber = i + series.bars.numbers.horizontalShift
                     var point = {
                         'x': shiftX(points[i]),
                         'y': shiftY(points[i+1])

--- a/jquery.flot.barnumbers.js
+++ b/jquery.flot.barnumbers.js
@@ -52,7 +52,7 @@
                 alignOffset = series.bars.align === "left" ? series.bars.barWidth / 2 : 0;
                 xAlign = series.bars.numbers.xAlign;
                 yAlign = series.bars.numbers.yAlign;
-				var shiftX = typeof xAlign == "number" ? function(x){ return x; } : xAlign;
+                var shiftX = typeof xAlign == "number" ? function(x){ return x; } : xAlign;
                 var shiftY = typeof yAlign == "number" ? function(y){ return y; } : yAlign;
     
                 axes = {

--- a/jquery.flot.barnumbers.js
+++ b/jquery.flot.barnumbers.js
@@ -48,7 +48,7 @@
                 var ctx = plot.getCanvas().getContext('2d');
                 var offset = plot.getPlotOffset();
                 ctx.textBaseline = "top";
-				ctx.textAlign = "center";
+                ctx.textAlign = "center";
                 alignOffset = series.bars.align === "left" ? series.bars.barWidth / 2 : 0;
 				xAlign = series.bars.numbers.xAlign;
                 yAlign = series.bars.numbers.yAlign;
@@ -61,7 +61,7 @@
                 } 
                 hs = series.bars.numbers.horizontalShift;
                 for(var i = 0; i < points.length; i += ps){
-					barNumber = i + series.bars.numbers.horizontalShift
+                	barNumber = i + series.bars.numbers.horizontalShift
                     var point = {
                         'x': shiftX(points[i]),
                         'y': shiftY(points[i+1])

--- a/jquery.flot.barnumbers.js
+++ b/jquery.flot.barnumbers.js
@@ -47,7 +47,7 @@
                 var points = series.datapoints.points;
                 var ctx = plot.getCanvas().getContext('2d');
                 var offset = plot.getPlotOffset();
-                ctx.textBaseline = "top";
+                ctx.textBaseline = "middle";
                 ctx.textAlign = "center";
                 alignOffset = series.bars.align === "left" ? series.bars.barWidth / 2 : 0;
                 xAlign = series.bars.numbers.xAlign;


### PR DESCRIPTION
The align option for a bar sets whatever is chosen on the grid line (i.e. the left-most portion of the bar starts at zero when left is selected), so when center was chosen the math was incorrect. This fixes it.

Screenshot of problem:
![image](https://cloud.githubusercontent.com/assets/1518719/3818773/12bc4514-1ce4-11e4-9040-df0e8e1114e9.png)

Screenshot of fix:
![image](https://cloud.githubusercontent.com/assets/1518719/3818800/4d9f8556-1ce4-11e4-8eec-cdf84ca2df53.png)

Sorry about all the useless white-space commits, relatively new to Git :)