### PR TITLE
Fix font string when setting size and weight

### DIFF
--- a/jquery.flot.barnumbers.js
+++ b/jquery.flot.barnumbers.js
@@ -72,9 +72,9 @@
                         ctx.strokeStyle = font.color;  // for better look
                     }
 
-                    var fontStr = font.weight ? font.weight : "";
+                    var fontStr = font.size ? font.size + "px" : "";
                     fontStr = font.style ? fontStr + " " + font.style : fontStr;
-                    fontStr = font.size ? fontStr + " " + font.size + "px" : fontStr;
+                    fontStr = font.weight ? fontStr + " " + font.weight : fontStr;
                     fontStr = font.family ? fontStr + " " + font.family : fontStr;
                     if (fontStr !== "") {
                         ctx.font = fontStr;


### PR DESCRIPTION
Setting weight to 'bold' and size to 30 would generate a string 'bold 30px', which did not work. It needs to be '30px bold'.