### PR TITLE
Add number rotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ There are other additional options
                 show : boolean,
                 xAlign : null or function like function (x) {return x + 0.5;}, (if null, the text is in the middle)
                 yAlign : null or function like function (y) {return y + 0.5;}, (if null, the text is in the middle)
-                font : {size : number, style : string, weight : string, family : string, color : string}
+                font : {size : number, style : string, weight : string, family : string, color : string},
+                rotate : number (representing degrees)
             }
         }
     }

--- a/jquery.flot.barnumbers.js
+++ b/jquery.flot.barnumbers.js
@@ -9,6 +9,7 @@
  *             xAlign : null or function like function (x) {return x + 0.5;}, (if null, the text is in the middle)
  *             yAlign : null or function like function (y) {return y + 0.5;}, (if null, the text is in the middle)
  *             font : {size : number, style : string, weight : string, family : string, color : string}
+ *             rotate : number
  *         }
  *     }
  * }
@@ -117,14 +118,34 @@
                     }
 
                     var c = plot.p2c(point);
-                    var txt = formatter(text)
+                    var txt = formatter(text);
 
-                    // stroke for better look
                     ctx.lineWidth = 0.2;
-                    ctx.strokeText(txt, c.left + offset.left, c.top + offset.top + 1);
 
-                    if (text != null) {
+                    // rotate the text the given degrees if provided (and is valid)
+                    if ($.isNumeric(series.bars.numbers.rotate)) {
+                      var degrees = series.bars.numbers.rotate;
+
+                      // save the context so we can restore to the previous canvas
+                      ctx.save();
+                      ctx.translate(c.left + offset.left, c.top + offset.top + 1);
+                      ctx.rotate(degrees * Math.PI / 180);
+
+                      // stroke for better look
+                      ctx.strokeText(txt, 0, 0);
+                      if (text != null) {
+                        ctx.fillText(txt, 0, 0);
+                      }
+
+                      // restore the canvas
+                      ctx.restore();
+
+                    } else {
+                      // stroke for better look
+                      ctx.strokeText(txt, c.left + offset.left, c.top + offset.top + 1);
+                      if (text != null) {
                         ctx.fillText(txt, c.left + offset.left, c.top + offset.top + 1);
+                      }
                     }
                 }
 

--- a/jquery.flot.barnumbers.js
+++ b/jquery.flot.barnumbers.js
@@ -122,6 +122,14 @@
 
                     ctx.lineWidth = 0.2;
 
+                    var writeText = function(text, x, y) {
+                      // stroke for better look
+                      ctx.strokeText(text, x, y);
+                      if (text != null) {
+                        ctx.fillText(text, x, y);
+                      }
+                    };
+
                     // rotate the text the given degrees if provided (and is valid)
                     if ($.isNumeric(series.bars.numbers.rotate)) {
                       var degrees = series.bars.numbers.rotate;
@@ -131,21 +139,14 @@
                       ctx.translate(c.left + offset.left, c.top + offset.top + 1);
                       ctx.rotate(degrees * Math.PI / 180);
 
-                      // stroke for better look
-                      ctx.strokeText(txt, 0, 0);
-                      if (text != null) {
-                        ctx.fillText(txt, 0, 0);
-                      }
+                      // write the label
+                      writeText(txt, 0, 0);
 
                       // restore the canvas
                       ctx.restore();
 
                     } else {
-                      // stroke for better look
-                      ctx.strokeText(txt, c.left + offset.left, c.top + offset.top + 1);
-                      if (text != null) {
-                        ctx.fillText(txt, c.left + offset.left, c.top + offset.top + 1);
-                      }
+                      writeText(txt, c.left + offset.left, c.top + offset.top + 1);
                     }
                 }
 


### PR DESCRIPTION
Add the ability to rotate the numbers on the canvas.

    series: {
        bars: {
            numbers : {
                show : boolean,
                ...
                rotate : number (representing degrees i.e. 45 or 90)
            }
        }
    }

This results in graphs like the following:

<img width="608" alt="screen shot 2015-09-28 at 8 44 24 pm" src="https://cloud.githubusercontent.com/assets/1641775/10154269/8465a100-6622-11e5-9900-10185fc60952.png">
